### PR TITLE
Added queue:watch Command

### DIFF
--- a/config/queue-watcher.php
+++ b/config/queue-watcher.php
@@ -2,7 +2,7 @@
 
 return [
     /*
-     * Horizon will be restarted when any PHP file inside these directories
+     * Laravel Queue will be restarted when any PHP file inside these directories
      * get created, updated or deleted. You can also specify other kinds
      * of files here.
      */
@@ -16,7 +16,7 @@ return [
     ],
 
     /*
-     * This command will be executed to start Horizon.
+     * This command will be executed to start Laravel Queue.
      */
     'command' => 'php artisan queue:work',
 ];

--- a/config/queue-watcher.php
+++ b/config/queue-watcher.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    /*
+     * Horizon will be restarted when any PHP file inside these directories
+     * get created, updated or deleted. You can also specify other kinds
+     * of files here.
+     */
+    'paths' => [
+        app_path(),
+        config_path(),
+        database_path(),
+        resource_path('views'),
+        base_path('.env'),
+        base_path('composer.lock'),
+    ],
+
+    /*
+     * This command will be executed to start Horizon.
+     */
+    'command' => 'php artisan queue:work',
+];

--- a/src/Commands/WatchQueueWorkCommand.php
+++ b/src/Commands/WatchQueueWorkCommand.php
@@ -3,6 +3,7 @@
 namespace Spatie\HorizonWatcher\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 use Spatie\Watcher\Watch;
 use Symfony\Component\Console\Command\Command as CommandAlias;
 use Symfony\Component\Process\Process;
@@ -30,7 +31,7 @@ class WatchQueueWorkCommand extends Command
 
     protected function startQueueWork(): bool
     {
-        $this->queueWorkProcess = Process::fromShellCommandline(config('queue-watcher.command') .'--queue=' . $this->option('queue'));
+        $this->queueWorkProcess = Process::fromShellCommandline(config('queue-watcher.command') . ' --queue=' . $this->option('queue'));
 
         $this->queueWorkProcess->setTty(true)->setTimeout(null);
 
@@ -70,7 +71,7 @@ class WatchQueueWorkCommand extends Command
 
     protected function restartQueue(): self
     {
-        $this->components->info('Change detected! Restarting Queue . ' . $this->option('queue') . '...');
+        $this->components->info('Change detected! Restarting Queue ' . $this->option('queue') . '...');
 
         $this->queueWorkProcess->stop();
 

--- a/src/Commands/WatchQueueWorkCommand.php
+++ b/src/Commands/WatchQueueWorkCommand.php
@@ -4,6 +4,7 @@ namespace Spatie\HorizonWatcher\Commands;
 
 use Illuminate\Console\Command;
 use Spatie\Watcher\Watch;
+use Symfony\Component\Console\Command\Command as CommandAlias;
 use Symfony\Component\Process\Process;
 
 class WatchQueueWorkCommand extends Command
@@ -21,7 +22,7 @@ class WatchQueueWorkCommand extends Command
         $queueWorkStarted = $this->startQueueWork();
 
         if (! $queueWorkStarted) {
-            return Command::FAILURE;
+            return CommandAlias::FAILURE;
         }
 
         $this->listenForChanges();

--- a/src/Commands/WatchQueueWorkCommand.php
+++ b/src/Commands/WatchQueueWorkCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Spatie\HorizonWatcher\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\Watcher\Watch;
+use Symfony\Component\Process\Process;
+
+class WatchQueueWorkCommand extends Command
+{
+    protected Process $queueWorkProcess;
+
+    protected $signature = 'queue:watch';
+
+    protected $description = 'Run Queue and restart it when PHP files are changed';
+
+    public function handle()
+    {
+        $this->components->info('Starting Queue and will restart it when any files change...');
+
+        $queueWorkStarted = $this->startQueueWork();
+
+        if (! $queueWorkStarted) {
+            return Command::FAILURE;
+        }
+
+        $this->listenForChanges();
+    }
+
+    protected function startQueueWork(): bool
+    {
+        $this->queueWorkProcess = Process::fromShellCommandline(config('queue-watcher.command'));
+
+        $this->queueWorkProcess->setTty(true)->setTimeout(null);
+
+        $this->queueWorkProcess->start(fn ($type, $output) => $this->info($output));
+
+        sleep(1);
+
+        return ! $this->queueWorkProcess->isTerminated();
+    }
+
+    protected function listenForChanges(): self {
+        Watch::paths(config('queue-watcher.paths'))
+            ->onAnyChange(function (string $event, string $path) {
+                if ($this->changedPathShouldRestartQueue($path)) {
+                    $this->restartQueue();
+                }
+            })
+            ->start();
+
+        return $this;
+    }
+
+    protected function changedPathShouldRestartQueue(string $path): bool
+    {
+        if($this->isPhpFile($path)) {
+            return true;
+        }
+
+        foreach (config('queue-watcher.paths') as $configuredPath) {
+            if($path === $configuredPath) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function restartQueue(): self
+    {
+        $this->components->info('Change detected! Restarting queue...');
+
+        $this->queueWorkProcess->stop();
+
+        $this->startQueueWork();
+
+        return $this;
+    }
+
+    protected function isPhpFile(string $path): bool
+    {
+        return str_ends_with(strtolower($path), '.php');
+    }
+}

--- a/src/Commands/WatchQueueWorkCommand.php
+++ b/src/Commands/WatchQueueWorkCommand.php
@@ -11,13 +11,13 @@ class WatchQueueWorkCommand extends Command
 {
     protected Process $queueWorkProcess;
 
-    protected $signature = 'queue:watch';
+    protected $signature = 'queue:watch {--queue=default}';
 
     protected $description = 'Run Queue and restart it when PHP files are changed';
 
     public function handle()
     {
-        $this->components->info('Starting Queue and will restart it when any files change...');
+        $this->components->info('Starting Queue ' . $this->option('queue') . ' and will restart it when any files change...');
 
         $queueWorkStarted = $this->startQueueWork();
 
@@ -30,7 +30,7 @@ class WatchQueueWorkCommand extends Command
 
     protected function startQueueWork(): bool
     {
-        $this->queueWorkProcess = Process::fromShellCommandline(config('queue-watcher.command'));
+        $this->queueWorkProcess = Process::fromShellCommandline(config('queue-watcher.command') .'--queue=' . $this->option('queue'));
 
         $this->queueWorkProcess->setTty(true)->setTimeout(null);
 
@@ -70,7 +70,7 @@ class WatchQueueWorkCommand extends Command
 
     protected function restartQueue(): self
     {
-        $this->components->info('Change detected! Restarting queue...');
+        $this->components->info('Change detected! Restarting Queue . ' . $this->option('queue') . '...');
 
         $this->queueWorkProcess->stop();
 

--- a/src/HorizonWatcherServiceProvider.php
+++ b/src/HorizonWatcherServiceProvider.php
@@ -13,8 +13,9 @@ class HorizonWatcherServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('laravel-horizon-watcher')
-            ->hasConfigFile()
-            ->hasCommand(WatchHorizonCommand::class)
+            ->hasConfigFile('horizon-watcher')
+            ->hasCommand(WatchHorizonCommand::class);
+        $package->hasConfigFile('queue-watcher')
             ->hasCommand(WatchQueueWorkCommand::class);
     }
 }

--- a/src/HorizonWatcherServiceProvider.php
+++ b/src/HorizonWatcherServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Spatie\HorizonWatcher;
 
 use Spatie\HorizonWatcher\Commands\WatchHorizonCommand;
+use Spatie\HorizonWatcher\Commands\WatchQueueWorkCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -13,6 +14,7 @@ class HorizonWatcherServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-horizon-watcher')
             ->hasConfigFile()
-            ->hasCommand(WatchHorizonCommand::class);
+            ->hasCommand(WatchHorizonCommand::class)
+            ->hasCommand(WatchQueueWorkCommand::class);
     }
 }

--- a/tests/WatchQueueWorkCommandTest.php
+++ b/tests/WatchQueueWorkCommandTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('will test', function () {
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
This PR introduced the `queue:watch` command which does the same as the `horizon:watch` command.

Additionally you can specify the queue option, to watch and restart a specific queue - useful if you are using multiple queues, even in development

For example:

`queue:watch --queue=my-queue`
