### PR TITLE
Kill child processes before exiting horizon

### DIFF
--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -85,6 +85,13 @@ class WatchHorizonCommand extends Command
 
     protected function stopHorizon(): void
     {
+        $this->killStrayHorizonProcesses();
+
+        $this->horizonProcess->stop();
+    }
+
+    protected function killStrayHorizonProcesses(): void
+    {
         (Process::fromShellCommandline('pgrep -P ' . $this->horizonProcess->getPid()))
             ->run(function ($type, $output) {
                 $childPids = explode("\n", $output);
@@ -96,7 +103,5 @@ class WatchHorizonCommand extends Command
                     (Process::fromShellCommandline('kill ' . $childPid))->run();
                 }
             });
-
-        $this->horizonProcess->stop();
     }
 }

--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -72,8 +72,7 @@ class WatchHorizonCommand extends Command
     {
         $this->components->info('Change detected! Restarting horizon...');
 
-        $this->horizonProcess->stop();
-
+        $this->stopHorizon();
         $this->startHorizon();
 
         return $this;
@@ -82,5 +81,22 @@ class WatchHorizonCommand extends Command
     protected function isPhpFile(string $path): bool
     {
         return str_ends_with(strtolower($path), '.php');
+    }
+
+    protected function stopHorizon(): void
+    {
+        (Process::fromShellCommandline('pgrep -P ' . $this->horizonProcess->getPid()))
+            ->run(function ($type, $output) {
+                $childPids = explode("\n", $output);
+                foreach ($childPids as $childPid) {
+                    if (! $childPid) {
+                        continue;
+                    }
+
+                    (Process::fromShellCommandline('kill ' . $childPid))->run();
+                }
+            });
+
+        $this->horizonProcess->stop();
     }
 }


### PR DESCRIPTION
I spend some more time looking into https://github.com/spatie/laravel-horizon-watcher/discussions/8 and found what was happening.
 
When staring horizon, child process is created that actually starts horizon, and when trying to stop, parent process gets into `defunct` state, and child process is kept alive.
Solution for this is to find child processes and kill them manually.

Found solution [here](https://github.com/symfony/symfony/issues/34406#issuecomment-1305706628) only re-wrote it using `Process` component.