### PR TITLE
Forward signal to process

### DIFF
--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -33,7 +33,7 @@ class WatchHorizonCommand extends Command
             ->setTty(! $this->option('without-tty'))
             ->setTimeout(null);
 
-        $this->trap([SIGINT, SIGTERM, SIGQUIT, SIGKILL], function ($signal): void {
+        $this->trap([SIGINT, SIGTERM, SIGQUIT], function ($signal): void {
             $this->trappedSignal = $signal;
 
             // Forward signal to Horizon process.

--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -33,7 +33,7 @@ class WatchHorizonCommand extends Command
             ->setTty(! $this->option('without-tty'))
             ->setTimeout(null);
 
-        $this->trap([SIGINT, SIGTERM], function ($signal): void {
+        $this->trap([SIGINT, SIGTERM, SIGQUIT, SIGKILL], function ($signal): void {
             $this->trappedSignal = $signal;
 
             // Forward signal to Horizon process.

--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -38,6 +38,7 @@ class WatchHorizonCommand extends Command
 
             // Forward signal to Horizon process.
             $this->horizonProcess->stop(signal: $signal);
+            $this->horizonProcess->wait();
         });
 
         $this->horizonProcess->start(fn ($type, $output) => $this->info($output));
@@ -83,6 +84,7 @@ class WatchHorizonCommand extends Command
         $this->components->info('Change detected! Restarting horizon...');
 
         $this->horizonProcess->stop();
+        $this->horizonProcess->wait();
 
         $this->startHorizon();
 

--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -20,13 +20,7 @@ class WatchHorizonCommand extends Command
     {
         $this->components->info('Starting Horizon and will restart it when any files change...');
 
-        $this->trap([SIGINT, SIGTERM], function ($signal): void {
-            $this->trappedSignal = $signal;
-        });
-
-        $horizonStarted = $this->startHorizon();
-
-        if (! $horizonStarted) {
+        if (! $this->startHorizon()) {
             return Command::FAILURE;
         }
 
@@ -35,9 +29,16 @@ class WatchHorizonCommand extends Command
 
     protected function startHorizon(): bool
     {
-        $this->horizonProcess = Process::fromShellCommandline(config('horizon-watcher.command'));
+        $this->horizonProcess = Process::fromShellCommandline(config('horizon-watcher.command'))
+            ->setTty(! $this->option('without-tty'))
+            ->setTimeout(null);
 
-        $this->horizonProcess->setTty(! $this->option('without-tty'))->setTimeout(null);
+        $this->trap([SIGINT, SIGTERM], function ($signal): void {
+            $this->trappedSignal = $signal;
+
+            // Forward signal to Horizon process.
+            $this->horizonProcess->stop(signal: $signal);
+        });
 
         $this->horizonProcess->start(fn ($type, $output) => $this->info($output));
 


### PR DESCRIPTION
Command doesn't forward signals to Horizon process to allow Horizon to shut down properly.

Fixes #16 