### PR TITLE
Add support to reflect changes in .env when restarting queue workers

### DIFF
--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -5,6 +5,7 @@ namespace Spatie\HorizonWatcher\Commands;
 use Illuminate\Console\Command;
 use Spatie\Watcher\Watch;
 use Symfony\Component\Process\Process;
+use Dotenv\Dotenv;
 
 class WatchHorizonCommand extends Command
 {
@@ -29,7 +30,10 @@ class WatchHorizonCommand extends Command
 
     protected function startHorizon(): bool
     {
-        $environment = $this->option('reload-config') ? \Dotenv\Dotenv::createArrayBacked(base_path())->load() : null;
+        $environment = $this->option('reload-config') 
+            ? Dotenv::createArrayBacked(base_path())->load() 
+            : null;
+        
         $this->horizonProcess = Process::fromShellCommandline(config('horizon-watcher.command'), null, $environment)
             ->setTty(! $this->option('without-tty'))
             ->setTimeout(null);

--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -10,7 +10,7 @@ class WatchHorizonCommand extends Command
 {
     protected Process $horizonProcess;
 
-    protected $signature = 'horizon:watch {--without-tty : Disable output to TTY}';
+    protected $signature = 'horizon:watch {--without-tty : Disable output to TTY} {--reload-config : Reload configuration every time a file changes}';
 
     protected $description = 'Run Horizon and restart it when PHP files are changed';
 
@@ -29,7 +29,8 @@ class WatchHorizonCommand extends Command
 
     protected function startHorizon(): bool
     {
-        $this->horizonProcess = Process::fromShellCommandline(config('horizon-watcher.command'))
+        $environment = $this->option('reload-config') ? \Dotenv\Dotenv::createArrayBacked(base_path())->load() : null;
+        $this->horizonProcess = Process::fromShellCommandline(config('horizon-watcher.command'), null, $environment)
             ->setTty(! $this->option('without-tty'))
             ->setTimeout(null);
 


### PR DESCRIPTION
Address an issue mentioned in this discussion: #41

Problem:
the queue worker child processes are called using the configuration that is loaded in the parent process. Therefor changes to environment variables are not reflected when jobs are processed.

Especially in a local environment changes to .env are common so the configuration being outdated has become a problem for our team.

Expected behaviour:
When restarting the queue workers the current configuration (read from .env or cached) is used.

Fix:
This fix adds an option to read the configuration on every restart and forward it to the queue worker child processes.
When omitting the option the watcher behaves exactly as before.