### PR TITLE
Make --reload-config use system env's

### DIFF
--- a/src/Commands/WatchHorizonCommand.php
+++ b/src/Commands/WatchHorizonCommand.php
@@ -4,6 +4,7 @@ namespace Spatie\HorizonWatcher\Commands;
 
 use Dotenv\Dotenv;
 use Illuminate\Console\Command;
+use Illuminate\Support\Env;
 use Spatie\Watcher\Watch;
 use Symfony\Component\Process\Process;
 
@@ -31,7 +32,11 @@ class WatchHorizonCommand extends Command
     protected function startHorizon(): bool
     {
         $environment = $this->option('reload-config')
-            ? Dotenv::createArrayBacked(base_path())->load()
+            ? Dotenv::create(
+				Env::getRepository(),
+				$this->laravel->environmentPath(),
+				$this->laravel->environmentFile()
+			)->load()
             : null;
 
         $this->horizonProcess = Process::fromShellCommandline(config('horizon-watcher.command'), null, $environment)


### PR DESCRIPTION
Right now if you use the --reload-config argument, it only looks at your `.env` and doesn't look at system ENV variables. This PR make it similar to laravel's [LoadEnvironmentVariables::createDotenv()](https://github.com/laravel/framework/blob/22f61b33090b57ab154e840752b0d2dbd0a7a3d7/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php#L86-L90) method. This way if you have ENVs in a docker config that override the .env file, they will be respected by the queue workers. This allows for connection host/port to be different depending if you are inside or outside of the docker box. See comment https://github.com/spatie/laravel-horizon-watcher/pull/44#issuecomment-2810338241

I tested this on my own machine and it worked well. Thanks for this package!